### PR TITLE
Add metadata prototype

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/mock v0.4.0
 	golang.org/x/exp v0.0.0-20240110193028-0dcbfd608b1e
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -102,5 +103,4 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION


#### Summary
This PR is to discuss on a something concrete for the common plugin metadata.

So there is custom field for plugin specific metadata and 4 common fields for any others.

It should look like something similar to below:

```yaml
server_version: 9.5.0
server_id: omzqcbrti7bq5kyfhybg3pbx4c
license_id: ntisr7wfwbghpyakh87fazbqma
plugin_id: com.mattermost.mattermost-plugin-metrics
custom:
    generated: 23 Jan 24 10:43 UTC
    max: 1706006580022
    min: 1705920180022
```


