### PR TITLE
WIP: add simple job mechanism

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -27,6 +29,12 @@ func newHandler(plugin *Plugin) *handler {
 	root.Use(handler.authorized)
 
 	root.HandleFunc("/download", handler.downloadDumpHandler).Methods(http.MethodGet)
+
+	jobs := root.PathPrefix("/jobs").Subrouter()
+	jobs.HandleFunc("", handler.getAllJobsHandler).Methods(http.MethodGet)
+	jobs.HandleFunc("/create", handler.createJobHandler).Methods(http.MethodPost)
+	jobs.HandleFunc("/delete/{id:[A-Za-z0-9]+}", handler.deleteJobHandler).Methods(http.MethodDelete)
+
 	handler.router = root
 
 	return handler
@@ -93,4 +101,78 @@ func (h *handler) downloadDumpHandler(w http.ResponseWriter, r *http.Request) {
 
 	appCfg := h.plugin.API.GetConfig()
 	web.WriteFileResponse(filepath.Base(fp), "application/zip", 0, max, *appCfg.ServiceSettings.WebserverMode, f, true, w, r)
+}
+
+type JobCreateRequest struct {
+	MinT int64
+	MaxT int64
+}
+
+func (h *handler) createJobHandler(w http.ResponseWriter, r *http.Request) {
+	var jcr JobCreateRequest
+	err := json.NewDecoder(r.Body).Decode(&jcr)
+	if err != nil {
+		h.plugin.API.LogError("error while processing the request", "err", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	job, err := h.plugin.CreateJob(r.Context(), jcr.MinT, jcr.MaxT)
+	if err != nil {
+		h.plugin.API.LogError("error while job create request", "err", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	b, err := json.Marshal(job)
+	if err != nil {
+		h.plugin.API.LogError("error while marshaling the job", "err", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(b)
+}
+
+func (h *handler) deleteJobHandler(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	if !model.IsValidId(id) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := h.plugin.DeleteJob(r.Context(), id); err != nil {
+		h.plugin.API.LogError("error while job create request", "err", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
+func (h *handler) getAllJobsHandler(w http.ResponseWriter, r *http.Request) {
+	jobs, err := h.plugin.GetAllJobs(r.Context())
+	if err != nil {
+		h.plugin.API.LogError("error while job create request", "err", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	jobSlice := make([]*DumpJob, len(jobs))
+	i := 0
+	for id := range jobs {
+		jobSlice[i] = jobs[id]
+		i++
+	}
+
+	sort.Slice(jobSlice, func(i, j int) bool {
+		return jobSlice[i].CreateAt > jobSlice[j].CreateAt
+	})
+
+	b, err := json.Marshal(jobSlice)
+	if err != nil {
+		h.plugin.API.LogError("error while marshaling the jobs", "err", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(b)
 }

--- a/server/const.go
+++ b/server/const.go
@@ -11,4 +11,6 @@ const (
 	zipFileName        = "tsdb_dump.tar.gz"
 	MaxRequestSize     = 5 * 1024 * 1024 // 5MB
 	localRetentionDays = 3 * 24 * time.Hour
+
+	jobManagerTick = time.Minute
 )

--- a/server/job.go
+++ b/server/job.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	root "github.com/mattermost/mattermost-plugin-metrics"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/pluginapi/cluster"
+)
+
+const (
+	JobPending = "pending"
+	JobRunning = "running"
+	JobError   = "failed"
+	JobTimeout = "timeout"
+	JobSucess  = "success"
+
+	JobLockKey    = PluginName + "_job"
+	KVStoreJobKey = "jobs"
+)
+
+type DumpJob struct {
+	ID           string `json:"ID"`
+	Status       string `json:"Status"`
+	CreateAt     int64  `json:"CreateAt"`
+	UpdateAt     int64  `jsob:"UpdateAt"`
+	MinT         int64  `json:"MinT"`
+	MaxT         int64  `json:"MaxT"`
+	DumpLocation string `json:"DumpLocation"`
+}
+
+// here it is required to acquire an exclusive lock to avoid
+// race in an HA environment if there are parallel job processing requests
+func (p *Plugin) lockJobKVMutex(ctx context.Context) (func(), error) {
+	lock, err := cluster.NewMutex(p.API, root.Manifest.Id)
+	if err != nil {
+		return nil, fmt.Errorf("could not acquire lock: %w", err)
+	}
+
+	if err = lock.LockWithContext(ctx); err != nil {
+		return nil, fmt.Errorf("could not lock the lock: %w", err)
+	}
+
+	return lock.Unlock, nil
+}
+
+func (p *Plugin) CreateJob(ctx context.Context, min, max int64) (*DumpJob, error) {
+	unlock, err := p.lockJobKVMutex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	job := &DumpJob{
+		ID:       model.NewId(),
+		Status:   JobPending,
+		CreateAt: time.Now().UnixMilli(),
+		MinT:     min,
+		MaxT:     max,
+	}
+
+	b, appErr := p.API.KVGet(KVStoreJobKey)
+	if appErr != nil {
+		return nil, fmt.Errorf("could not retreive jobs: %w", appErr)
+	}
+
+	// var jobsRaw map[string]json.RawMessage
+	jobs := make(map[string]*DumpJob)
+
+	if len(b) > 0 {
+		err = json.Unmarshal(b, &jobs)
+		if err != nil {
+			return nil, fmt.Errorf("could not unmarshal jobs: %w", err)
+		}
+	}
+
+	jobs[job.ID] = job
+
+	b, err = json.Marshal(jobs)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal jobs: %w", err)
+	}
+
+	appErr = p.API.KVSet(KVStoreJobKey, b)
+	if appErr != nil {
+		return nil, fmt.Errorf("could not store jobs: %w", appErr)
+	}
+
+	return job, nil
+}
+
+func (p *Plugin) GetAllJobs(ctx context.Context) (map[string]*DumpJob, error) {
+	unlock, err := p.lockJobKVMutex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	b, appErr := p.API.KVGet(KVStoreJobKey)
+	if appErr != nil {
+		return nil, fmt.Errorf("could not retreive jobs: %w", appErr)
+	}
+
+	var jobs map[string]*DumpJob
+	err = json.Unmarshal(b, &jobs)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal jobs: %w", err)
+	}
+
+	return jobs, nil
+}
+
+func (p *Plugin) DeleteJob(ctx context.Context, id string) error {
+	unlock, err := p.lockJobKVMutex(ctx)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	b, appErr := p.API.KVGet(KVStoreJobKey)
+	if appErr != nil {
+		return fmt.Errorf("could not retreive jobs: %w", appErr)
+	}
+
+	var jobs map[string]*DumpJob
+	err = json.Unmarshal(b, &jobs)
+	if err != nil {
+		return fmt.Errorf("could not unmarshal jobs: %w", err)
+	}
+
+	if _, ok := jobs[id]; !ok {
+		return fmt.Errorf("job does not exist: %s", id)
+	}
+
+	delete(jobs, id)
+
+	b, err = json.Marshal(jobs)
+	if err != nil {
+		return fmt.Errorf("could not marshal jobs: %w", err)
+	}
+
+	appErr = p.API.KVSet(KVStoreJobKey, b)
+	if appErr != nil {
+		return fmt.Errorf("could not store jobs: %w", appErr)
+	}
+
+	return nil
+}

--- a/server/job_manager.go
+++ b/server/job_manager.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+type JobManager struct {
+	ticker    *time.Ticker
+	closeChan chan bool
+	wg        sync.WaitGroup
+	plugin    *Plugin
+}
+
+// jobManager constantly polls the kvstore and starts the pending jobs
+// if a job is in running state and not updated, manager will set its
+// state to JobTimeout.
+func (m *JobManager) run(ctx context.Context) {
+	m.wg.Add(1)
+	defer m.wg.Done()
+
+	for {
+		select {
+		case <-m.ticker.C:
+			jobs, err := m.plugin.GetAllJobs(context.TODO())
+			if err != nil {
+				m.plugin.API.LogError("manager could not retrieve dump jobs", "err", err)
+			}
+
+			unlock, err := m.plugin.lockJobKVMutex(ctx)
+			if err != nil {
+				m.plugin.API.LogError("manager could not acquire job lock", "err", err)
+				continue
+			}
+			for _, job := range jobs {
+				switch job.Status {
+				case JobPending:
+					if job.UpdateAt < time.Now().Add(-5*time.Minute).UnixMilli() {
+						m.plugin.API.LogWarn("Setting obsolete job status to fail", "id", job.ID)
+						job.Status = JobTimeout
+						continue
+					}
+					m.plugin.API.LogInfo("job pending", "id", job.ID)
+				case JobRunning:
+					// check if it needs to be timed out
+				default:
+					continue
+				}
+			}
+			b, err := json.Marshal(jobs)
+			if err != nil {
+				m.plugin.API.LogError("manager could not marshal jobs", "err", err)
+				unlock()
+				continue
+			}
+			appErr := m.plugin.API.KVSet(KVStoreJobKey, b)
+			if appErr != nil {
+				m.plugin.API.LogError("manager could not update job statuses", "err", appErr)
+			}
+			unlock()
+		case <-m.closeChan:
+			return
+		}
+	}
+}
+
+func (m *JobManager) stop() error {
+	m.ticker.Stop()
+	close(m.closeChan)
+
+	m.wg.Wait()
+
+	return nil
+}


### PR DESCRIPTION

#### Summary
Adds simple job framework so that we can asynchronously process dump generation requests. Still in early phase, and I wanted to get an early review hence tests are not included.

We are basically leveraging the plugin mutexes to handle jobs. All job CRUD actions are done by acquiring a lock. There is a job manager which runs constantly to check job health and update its status accordingly.
