### PR TITLE
server: never give up on trying

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -11,4 +11,5 @@ const (
 	zipFileName        = "tsdb_dump.tar.gz"
 	MaxRequestSize     = 5 * 1024 * 1024 // 5MB
 	localRetentionDays = 3 * 24 * time.Hour
+	maxPingTrials      = 10
 )

--- a/server/sync.go
+++ b/server/sync.go
@@ -56,7 +56,6 @@ loop:
 				continue
 			}
 		case <-p.closeChan:
-			p.API.LogDebug("Filestore sync job stopped")
 			return
 		}
 	}


### PR DESCRIPTION

#### Summary
While testing the plugin on community, I came across to several occurrences of plugin not starting to scraping after a node restart. It may be a case if the lock is not being acquired. The goal of this PR is to improve logging and let plugins try to acquire the lock continuously. The attempt will be done in 60 seconds so it's not a big deal.
