### PR TITLE
[MM-59066] server/job: prevent deletion of non-finished jobs

### DIFF
--- a/server/job.go
+++ b/server/job.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	root "github.com/mattermost/mattermost-plugin-metrics"
@@ -181,12 +182,12 @@ func (p *Plugin) DeleteJob(ctx context.Context, id string) error {
 		return nil
 	}
 
-	err = p.fileBackend.RemoveDirectory(filepath.Dir(jobs[id].DumpLocation))
-	if err != nil {
+	if ok, err := jobs[id].DeleteDump(p); err != nil {
 		p.API.LogError("dump could not be deleted", "id", jobs[id].ID, "err", err.Error())
-	} else {
+	} else if ok {
 		p.API.LogDebug("dump deleted", "id", jobs[id].ID, "file", jobs[id].DumpLocation)
 	}
+
 	delete(jobs, id)
 
 	b, err = json.Marshal(jobs)
@@ -258,4 +259,22 @@ func (p *Plugin) UpdateJob(ctx context.Context, job *DumpJob) error {
 	}
 
 	return nil
+}
+
+func (j *DumpJob) DeleteDump(p *Plugin) (bool, error) {
+	// do not delete if the dump location is not under the plugin-data directory
+	// there is a corner case that; if the job receives a deletion request,
+	// the dump location will be empty and therefore `filepath.Dir(jobs[id].DumpLocation)`
+	// will return "." which would tell fileBackend to delete entire data directory.
+	if loc := j.DumpLocation; strings.HasPrefix(loc, filepath.Join(pluginDataDir, PluginName)) {
+		err := p.fileBackend.RemoveDirectory(filepath.Dir(j.DumpLocation))
+		if err != nil {
+			return false, err
+		} else {
+			return true, nil
+		}
+	}
+
+	// there were no dump under the plugin-data/mattermost-plugin-metrics so it's been ignored
+	return false, nil
 }

--- a/server/job.go
+++ b/server/job.go
@@ -182,8 +182,9 @@ func (p *Plugin) DeleteJob(ctx context.Context, id string) error {
 		return nil
 	}
 
-	if ok, err2 := jobs[id].DeleteDump(p); err2 != nil {
-		p.API.LogError("dump could not be deleted", "id", jobs[id].ID, "err", err2.Error())
+	ok, err := jobs[id].DeleteDump(p);
+	if  err != nil {
+		p.API.LogError("dump could not be deleted", "id", jobs[id].ID, "err", err.Error())
 	} else if ok {
 		p.API.LogDebug("dump deleted", "id", jobs[id].ID, "file", jobs[id].DumpLocation)
 	}

--- a/server/job.go
+++ b/server/job.go
@@ -182,8 +182,8 @@ func (p *Plugin) DeleteJob(ctx context.Context, id string) error {
 		return nil
 	}
 
-	ok, err := jobs[id].DeleteDump(p);
-	if  err != nil {
+	ok, err := jobs[id].DeleteDump(p)
+	if err != nil {
 		p.API.LogError("dump could not be deleted", "id", jobs[id].ID, "err", err.Error())
 	} else if ok {
 		p.API.LogDebug("dump deleted", "id", jobs[id].ID, "file", jobs[id].DumpLocation)

--- a/server/job_test.go
+++ b/server/job_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"path/filepath"
 	"testing"
 
@@ -13,6 +14,10 @@ func TestDeleteDump(t *testing.T) {
 		DriverName: "local",
 		Directory:  t.TempDir(),
 	})
+	require.NoError(t, err)
+
+	testFile := "test.txt"
+	_, err = fs.WriteFile(bytes.NewReader([]byte("random text")), testFile)
 	require.NoError(t, err)
 
 	plugin := &Plugin{
@@ -47,5 +52,10 @@ func TestDeleteDump(t *testing.T) {
 		success, err := job.DeleteDump(plugin)
 		require.NoError(t, err)
 		require.False(t, success)
+
+		// should not delete other files
+		b, err := fs.ReadFile(testFile)
+		require.NoError(t, err)
+		require.Equal(t, "random text", string(b))
 	})
 }

--- a/server/job_test.go
+++ b/server/job_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/v8/platform/shared/filestore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteDump(t *testing.T) {
+	fs, err := filestore.NewFileBackend(filestore.FileBackendSettings{
+		DriverName: "local",
+		Directory:  t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	plugin := &Plugin{
+		fileBackend: fs,
+	}
+
+	t.Run("Successfully delete dump directory", func(t *testing.T) {
+		job := &DumpJob{
+			DumpLocation: filepath.Join(pluginDataDir, PluginName, "some-dump"),
+		}
+
+		success, err := job.DeleteDump(plugin)
+		require.NoError(t, err)
+		require.True(t, success)
+	})
+
+	t.Run("Dump location not under plugin-data directory", func(t *testing.T) {
+		job := &DumpJob{
+			DumpLocation: "/some-other-dir/some-dump",
+		}
+
+		success, err := job.DeleteDump(plugin)
+		require.NoError(t, err)
+		require.False(t, success)
+	})
+
+	t.Run("Empty dump location", func(t *testing.T) {
+		job := &DumpJob{
+			DumpLocation: "",
+		}
+
+		success, err := job.DeleteDump(plugin)
+		require.NoError(t, err)
+		require.False(t, success)
+	})
+}


### PR DESCRIPTION


#### Summary
An issue has been pointed out that if a “Remove All” request is being made during a job is running will led to a case that plugin to delete entire data directory. So, the logic was deleting the directory of the dump. But the problem is, if a job receives a request to be deleted, and it doesn’t have a dump directory (which would be set after the job finishes), it will have an empty value. And if the empty value is given to filestore, the entire data directory will be deleted.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59066

