### PR TITLE
[MM-59278] Add metadata to generated Dump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/gorilla/mux v1.8.1
 	github.com/jmoiron/sqlx v1.3.5
-	github.com/mattermost/mattermost/server/public v0.1.1
+	github.com/mattermost/mattermost/server/public v0.1.5-0.20240628142051-59e413e31b37
 	github.com/mattermost/mattermost/server/v8 v8.0.0-20240326175929-75cf1f9d931a
 	github.com/mattermost/squirrel v0.4.0
 	github.com/oklog/ulid v1.3.1
@@ -44,7 +44,9 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,7 @@ github.com/hashicorp/consul/api v1.25.1 h1:CqrdhYzc8XZuPnhIYZWH45toM0LB9ZeYr/gvp
 github.com/hashicorp/consul/api v1.25.1/go.mod h1:iiLVwR/htV7mas/sy0O+XSuEnrdBUUydemjxcUrAt4g=
 github.com/hashicorp/cronexpr v1.1.2 h1:wG/ZYIKT+RT3QkOdgYc+xsKWVRgnxJ1OJtjjy84fJ9A=
 github.com/hashicorp/cronexpr v1.1.2/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
@@ -352,8 +353,8 @@ github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956 h1:Y1Tu/swM31pVwwb
 github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956/go.mod h1:SRl30Lb7/QoYyohYeVBuqYvvmXSZJxZgiV3Zf6VbxjI=
 github.com/mattermost/logr/v2 v2.0.21 h1:CMHsP+nrbRlEC4g7BwOk1GAnMtHkniFhlSQPXy52be4=
 github.com/mattermost/logr/v2 v2.0.21/go.mod h1:kZkB/zqKL9e+RY5gB3vGpsyenC+TpuiOenjMkvJJbzc=
-github.com/mattermost/mattermost/server/public v0.1.1 h1:T5UtZ0SB3rZvhiKFUxkPn4fNrEQTXAcmCHVkRct1dpk=
-github.com/mattermost/mattermost/server/public v0.1.1/go.mod h1:WeqCPudYLqk4HjjGvCMJwhtHMVvcNUTHIbrLmLjAD+4=
+github.com/mattermost/mattermost/server/public v0.1.5-0.20240628142051-59e413e31b37 h1:kL1piLaVyu8wHIn4k/Ozv6OhYbAtyBiFpHI+w2S/rsU=
+github.com/mattermost/mattermost/server/public v0.1.5-0.20240628142051-59e413e31b37/go.mod h1:PDPb/iqzJJ5ZvK/m70oDF55AXN/cOvVFj96Yu4e6j+Q=
 github.com/mattermost/mattermost/server/v8 v8.0.0-20240326175929-75cf1f9d931a h1:yPsYDtyoI98gzIPyAt7AxgtYqFq9qhp6oA1ss3O2hp8=
 github.com/mattermost/mattermost/server/v8 v8.0.0-20240326175929-75cf1f9d931a/go.mod h1:qQjPPGKiugHw6Tunlmq3cVDkKFFbgtMxIvyNJoN+p3Y=
 github.com/mattermost/squirrel v0.4.0 h1:azf9LZ+8JUTAvwt/njB1utkPqWQ6e7Rje2ya5N0P2i4=

--- a/server/dump.go
+++ b/server/dump.go
@@ -87,6 +87,17 @@ func (p *Plugin) createDump(ctx context.Context, id string, min, max time.Time, 
 		return nil, err
 	}
 
+	// Add plugin specific metadata
+	customMetadata := map[string]any{
+		"min": min.UnixMilli(),
+		"max": max.UnixMilli(),
+	}
+
+	_, err = p.client.System.GeneratePacketMetadata(dumpDir, customMetadata)
+	if err != nil {
+		return nil, err
+	}
+
 	err = compressDirectory(dumpDir, tempZipFile)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### Summary

Example output

```yaml
version: 1
type: plugin-packet
generated_at: 1719827284263
server_version: 9.10.0
server_id: ciu8wqr7mbbqjb74cao5t6a5gh
license_id: ntisr7wfwbghpyakh87fazbqma
customer_id: p9un369a67gimj4yd6i6ib39wh
extras:
  max: 1719612000000
  min: 1719439200000
  plugin_id: com.mattermost.mattermost-plugin-metrics
  plugin_version: 0.5.0
```

Resubmission of https://github.com/mattermost/mattermost-plugin-metrics/pull/13

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59278
