### PR TITLE
[MM-58393] server/plugin: ensure metrics are enabled on server

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -119,6 +119,15 @@ func (p *Plugin) OnActivate() error {
 		p.singletonLockAcquired = true
 	}
 
+	// The metrics plugin is dependent on the metrics endpoint being expoesed, so we need to ensure it is enabled.
+	if cfg := p.API.GetUnsanitizedConfig(); cfg.MetricsSettings.Enable == nil || !*cfg.MetricsSettings.Enable {
+		p.API.LogInfo("Enabling metrics...")
+		cfg.MetricsSettings.Enable = mmModel.NewBool(true)
+		if err2 := p.API.SaveConfig(cfg); err2 != nil {
+			return fmt.Errorf("failed to save config: %w", err2)
+		}
+	}
+
 	p.closeChan = make(chan bool)
 	p.waitGroup = sync.WaitGroup{}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -121,10 +121,12 @@ func (p *Plugin) OnActivate() error {
 
 	// The metrics plugin is dependent on the metrics endpoint being expoesed, so we need to ensure it is enabled.
 	if cfg := p.API.GetUnsanitizedConfig(); cfg.MetricsSettings.Enable == nil || !*cfg.MetricsSettings.Enable {
-		p.API.LogInfo("Enabling metrics...")
-		cfg.MetricsSettings.Enable = mmModel.NewBool(true)
-		if err2 := p.API.SaveConfig(cfg); err2 != nil {
-			return fmt.Errorf("failed to save config: %w", err2)
+		if lic := p.API.GetLicense(); lic != nil && *lic.Features.Metrics == true {
+			p.API.LogInfo("Enabling metrics...")
+			cfg.MetricsSettings.Enable = mmModel.NewBool(true)
+			if err2 := p.API.SaveConfig(cfg); err2 != nil {
+				return fmt.Errorf("failed to save config: %w", err2)
+			}
 		}
 	}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -121,7 +121,7 @@ func (p *Plugin) OnActivate() error {
 
 	// The metrics plugin is dependent on the metrics endpoint being expoesed, so we need to ensure it is enabled.
 	if cfg := p.API.GetUnsanitizedConfig(); cfg.MetricsSettings.Enable == nil || !*cfg.MetricsSettings.Enable {
-		if lic := p.API.GetLicense(); lic != nil && *lic.Features.Metrics == true {
+		if lic := p.API.GetLicense(); lic != nil && *lic.Features.Metrics {
 			p.API.LogInfo("Enabling metrics...")
 			cfg.MetricsSettings.Enable = mmModel.NewBool(true)
 			if err2 := p.API.SaveConfig(cfg); err2 != nil {


### PR DESCRIPTION


#### Summary
We enable the metrics endpoint by default, it's to reduce admin action if the plugin is deployed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58393

