### PR TITLE
bump version in plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
     "description": "This plugin serves as a openmetrics scraper for Mattermost. It can be used to store metrics data without Prometheus.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-metrics",
     "support_url": "https://github.com/mattermost/mattermost-plugin-metrics/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-metrics/releases/tag/v0.5.0",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-metrics/releases/tag/v0.5.3",
     "icon_path": "assets/starter-template-icon.svg",
-    "version": "0.5.0",
+    "version": "0.5.3",
     "min_server_version": "6.3.0",
     "server": {
         "executables": {


### PR DESCRIPTION


#### Summary
`make patch` doesn't seem to be bumping `plugin.json`. I'll cut a new release once this one gets merged.


